### PR TITLE
Bump JDK version from 21 to 25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <!-- OUR VERSION -->
         <revision>1.0.0-SNAPSHOT</revision>
         <!-- DEPENDENCIES VERSION -->
-        <jdk.version>21</jdk.version>
+        <jdk.version>25</jdk.version>
         <cds.services.version>4.9.0</cds.services.version>
         <spring.boot.version>3.4.5</spring.boot.version>
         <spring.boot.version>3.5.11</spring.boot.version>


### PR DESCRIPTION
# Bump JDK Version from 21 to 25

### Chore

🔧 Updated the project's JDK version from 21 to 25 in the Maven build configuration.

### Changes

* `pom.xml`: Updated the `jdk.version` property from `21` to `25`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- File Content Strategy: Full file content
- Correlation ID: `6332ac15-a2fb-4af4-92db-7d78f29b64c3`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
